### PR TITLE
Update .eslintrc.cjs

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:prettier/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   "parserOptions": {
     "project": ["tsconfig.json"]


### PR DESCRIPTION
ignorePatterns was duplicated and contained two overlapping entries so the first one which had less could be removed.